### PR TITLE
GEOMESA-9 Duplicate Features can become duplicate rows

### DIFF
--- a/geomesa-core/src/test/scala/geomesa/core/index/FormattersTest.scala
+++ b/geomesa-core/src/test/scala/geomesa/core/index/FormattersTest.scala
@@ -16,18 +16,11 @@
 
 package geomesa.core.index
 
-import com.vividsolutions.jts.geom._
-import geomesa.utils.text.WKTUtils
-import org.apache.accumulo.core.data.Key
 import org.geotools.data.DataUtilities
-import org.joda.time.DateTime
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
-import scala.util.Try
-import org.geotools.feature.simple.SimpleFeatureBuilder
 import org.opengis.feature.simple.SimpleFeature
-import java.util.Date
 
 @RunWith(classOf[JUnitRunner])
 class FormattersTest extends Specification {
@@ -48,8 +41,5 @@ class FormattersTest extends Specification {
 
       shardNumbers.size must be equalTo 1
     }
-
-    // NB:  As desirable as it might be to have a test for features
-    // with null IDs, there was no obvious way to create one.
   }
 }

--- a/geomesa-core/src/test/scala/geomesa/core/iterators/SpatioTemporalIntersectingIteratorTest.scala
+++ b/geomesa-core/src/test/scala/geomesa/core/iterators/SpatioTemporalIntersectingIteratorTest.scala
@@ -156,9 +156,7 @@ class SpatioTemporalIntersectingIteratorTest extends Specification {
       }).toList
     }
 
-    val pointWithNoID = List[Entry](
-      Entry("POINT(-78.0, 38.0)", null)
-    )
+    val pointWithNoID = List(Entry("POINT(-78.0 38.0)", null))
 
     val shortListOfPoints = List[Entry](
       Entry("POINT(47.2 25.6)", "1"), // hit
@@ -414,10 +412,10 @@ class SpatioTemporalIntersectingIteratorTest extends Specification {
   }
 
   "Feature with a null ID" should {
-    "fail to insert" in {
+    "not fail to insert" in {
       val c = Try(TestData.setupMockAccumuloTable(TestData.pointWithNoID, TestData.pointWithNoID.length))
 
-      c.isFailure must be equalTo true
+      c.isFailure must be equalTo false
     }
   }
 }


### PR DESCRIPTION
The partition formatter now computes the shard number from
a hash of the feature ID.  (In the unlikely event that the
feature has a <NULL> ID, the hash is computed on the feature's
full string form.)
